### PR TITLE
Enhanced error reporting + client IP forwarding

### DIFF
--- a/apis/apnscp_api.php
+++ b/apis/apnscp_api.php
@@ -8,8 +8,14 @@
  * @license http://www.blesta.com/license/ The Blesta License Agreement
  * @link http://www.blesta.com/ Blesta
  */
+
+use Blesta\Core\Util\Common\Traits\Container;
+
 class ApnscpApi
 {
+    // Load traits
+    use Container;
+
     /**
      * @var string The server hostname
      */
@@ -62,6 +68,11 @@ class ApnscpApi
         // Create SOAP connection
         ini_set('default_socket_timeout', 5000);
 
+	$headers = [
+            'Abort-On: error',
+            'X-Forwarded-For: ' . $this->getFromContainer('requestor')->ip_address
+	];
+
         $client = new SoapClient($soap_location . '/apnscp.wsdl', [
             'location' => $soap_location . '/soap?authkey=' . $this->api_key,
             'uri' => 'urn:net.apnscp.soap',
@@ -70,6 +81,9 @@ class ApnscpApi
                 'ssl' => [
                     'verify_peer' => false,
                     'verify_peer_name' => false
+	        ],
+		'http' => [
+                    'header' => implode("\r\n", $headers) . "\r\n"
                 ]
             ])
         ]);


### PR DESCRIPTION
This commit brings two changes, the first of which is intended to disinter the root cause of a site creation failure. Second allows auth sharing for other areas, such as [rampart:unban](https://api.apiscp.com/class-Rampart_Module.html#_unban) that, when called, would allow a client to unblock their IP address within Blesta.

- Abort operation whenever an error is raised. Prior, only a fatal would halt execution which requires traversal to ascertain root cause that is outside the responsibilities of any module. Now, errors encountered during site management immediately bubble up

- Pass client IP address to ApisCP for auth logging. Requires additional configuration in [core] => http_trusted_forward in panel