### PR TITLE
"reset" parameter merged into service parameters

### DIFF
--- a/apis/apnscp_api.php
+++ b/apis/apnscp_api.php
@@ -217,7 +217,7 @@ class ApnscpApi
      */
     public function updateAccountPlan($params)
     {
-        return $this->apiRequest('admin_edit_site', [$params['domain'], ['siteinfo.plan' => $params['plan'], ['reset' => true]]]);
+        return $this->apiRequest('admin_edit_site', [$params['domain'], ['siteinfo.plan' => $params['plan']], ['reset' => true]]);
     }
 
     /**


### PR DESCRIPTION
Resolves the following error when attempting to change plans:

```
fatal(): service `0' unknown - disable strict interpretation or install service
```